### PR TITLE
Update js/jquery.stickytableheaders.js

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -37,6 +37,7 @@
 				base.$clonedHeader.css({
 					'position': 'fixed',
 					'top': 0,
+					'z-index':99999
 					'left': $this.css('margin-left'),
 					'display': 'none'
 				});


### PR DESCRIPTION
added z-index to tableFloatingHeader to fix overlaying issues with other rows styled with css3 gradients
