### PR TITLE
Use jQuery's outerWidth() to get rid off padding/border offsets

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -113,7 +113,7 @@
 				var $this = $(this);
 				var $origCell = $('th', base.$originalHeader).eq(index);
 				this.className = $origCell.attr('class') || '';
-				$this.css('width', $origCell.width());
+				$this.css('width', $origCell.outerWidth());
 			});
 
 			// Copy row width from whole table


### PR DESCRIPTION
this should fix slightly off issues with cell's width in floatingHeader
