### PR TITLE
Fix for floating header blocking content under table

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -80,7 +80,7 @@
 				var scrollTop = base.$window.scrollTop() + newTopOffset;
 				var scrollLeft = base.$window.scrollLeft();
 
-				if ((scrollTop > offset.top) && (scrollTop < offset.top + $this.height())) {
+				if ((scrollTop > offset.top) && (scrollTop < offset.top + $this.height() - base.$clonedHeader.height())) {
 					var newLeft = offset.left - scrollLeft;
 					if (base.isCloneVisible && (newLeft === base.leftOffset) && (newTopOffset === base.topOffset)) {
 						return;


### PR DESCRIPTION
Basically, this just figures in the height of the floating header when it decides when to hide it, so that it hides a little bit earlier.
