### PR TITLE
Bootstrap navbar compatibility fix

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -6,7 +6,8 @@
 
 	var pluginName = 'stickyTableHeaders';
 	var defaults = {
-			fixedOffset: 0
+			fixedOffset: 0,
+			marginTop: 0			
 		};
 
 	function Plugin (el, options) {
@@ -88,7 +89,7 @@
 
 					base.$clonedHeader.css({
 						'top': newTopOffset,
-						'margin-top': 0,
+						'margin-top': base.options.marginTop,
 						'left': newLeft,
 						'display': 'block'
 					});


### PR DESCRIPTION
Add an override for margin-top, so it can easily be used with the bootstrap navbar. By creating it like this: $("html:not(.legacy) table").stickyTableHeaders({marginTop:'40px'});

If there's another way to do this I apologize, but this seemed the most straight-forward.
