### PR TITLE
fix border-collapse issue

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -208,7 +208,7 @@
 				    var $origTh = $('th', base.$originalHeader);
 				    if ($origTh.css('border-collapse') === 'collapse') {
 				        if (document.defaultView && document.defaultView.getComputedStyle) { // standard (includes ie9)
-				            width = document.defaultView.getComputedStyle(this, null).width();
+				            width = parseFloat(document.defaultView.getComputedStyle(this, null).width);
 				        } else {
 				            var leftPadding = parseFloat($this.css("padding-left"));
 				            var rightPadding = parseFloat($this.css("padding-right"));


### PR DESCRIPTION
using getComputedStyle when the table is border-collapse instead of jQuery width()

this commit fixes #17

This commit fixes a bug I created with the last commit.
