### PR TITLE
removing extra unbinds to fix 

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -108,8 +108,6 @@
 				base.$window.off('.' + name + base.id, base.toggleHeaders);
 			}
 			base.$scrollableArea.off('.' + name, base.updateWidth);
-			base.$el.off('.' + name);
-			base.$el.find('*').off('.' + name);
 		};
 
 		base.toggleHeaders = function () {


### PR DESCRIPTION
fixes https://github.com/jmosbech/StickyTableHeaders/issues/70
- Error: Maximum call stack size exceeded.
