### PR TITLE
Decimal point cell widths

### DIFF
--- a/jquery.stickytableheaders.js
+++ b/jquery.stickytableheaders.js
@@ -197,7 +197,7 @@
 				var width, $this = $(this);
 
 				if ($this.css('box-sizing') === 'border-box') {
-					width = $this.outerWidth(); // #39: border-box bug
+					width = $this[0].getBoundingClientRect().width; // #39: border-box bug
 				} else {
 					var $origTh = $('th', base.$originalHeader);
 					if ($origTh.css('border-collapse') === 'collapse') {


### PR DESCRIPTION
I ran into a scenario whereby I had a table with `box-sizing: border-box` and `table-layout: fixed`. Under the covers the browser (Firefox) was calculating the cell widths with not as absolute int values but with decimal points. The jQuery `outerWidth()` only returns the rounded number. Thus the sticky header never quite matched the rest of the table.

To solve this I switched the measurement of the cell width to `$this[0].getBoundingClientRect().width` which returns the full decimal value.