### PR TITLE
Fix: IE8 has no 'width' property on 'getBoundingClientRect()'; compensating with simple math

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -198,7 +198,12 @@
 				var width, $this = $(this);
 
 				if ($this.css('box-sizing') === 'border-box') {
-					width = $this[0].getBoundingClientRect().width; // #39: border-box bug
+          var boundingClientRect = $this[0].getBoundingClientRect();
+          if(boundingClientRect.width) {
+            width = boundingClientRect.width; // #39: border-box bug
+          } else {
+            width = boundingClientRect.right - boundingClientRect.left; // ie8 bug: getBoundingClientRect() does not have a width property
+          }
 				} else {
 					var $origTh = $('th', base.$originalHeader);
 					if ($origTh.css('border-collapse') === 'collapse') {

--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -198,12 +198,12 @@
 				var width, $this = $(this);
 
 				if ($this.css('box-sizing') === 'border-box') {
-          var boundingClientRect = $this[0].getBoundingClientRect();
-          if(boundingClientRect.width) {
-            width = boundingClientRect.width; // #39: border-box bug
-          } else {
-            width = boundingClientRect.right - boundingClientRect.left; // ie8 bug: getBoundingClientRect() does not have a width property
-          }
+					var boundingClientRect = $this[0].getBoundingClientRect();
+					if(boundingClientRect.width) {
+						width = boundingClientRect.width; // #39: border-box bug
+					} else {
+						width = boundingClientRect.right - boundingClientRect.left; // ie8 bug: getBoundingClientRect() does not have a width property
+					}
 				} else {
 					var $origTh = $('th', base.$originalHeader);
 					if ($origTh.css('border-collapse') === 'collapse') {


### PR DESCRIPTION
I encountered this issue while trying to debug why the headers were not being resized properly.  Upon investigation, I found that the `getBoundingClientRect()` object in IE8 had no `width` property, but did have a `left` and `right`.  Subtracting `left` from `right` yields the desired width.

In my tests, this did the trick for IE8, and didn't break functionality for any other browser.


**Demo:** https://jsfiddle.net/dimak25/76Lvpejw/
**Output-only link:** http://fiddle.jshell.net/dimak25/76Lvpejw/9/show/  (IE8 refuses to render jsFiddle properly)
