### PR TITLE
Update jquery.stickytableheaders.js

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -9,6 +9,7 @@
 		defaults = {
 			fixedOffset: 0,
 			leftOffset: 0,
+			fixScrollLeft: false, /*true if have probleme with thead horizontal scroll*/
 			marginTop: 0,
 			objDocument: document,
 			objHead: 'head',
@@ -136,7 +137,10 @@
 								(offset.top + $this.height() - base.$clonedHeader.height() - (base.isWindowScrolling ? 0 : newTopOffset));
 
 					if (scrolledPastTop && notScrolledPastBottom) {
-						newLeft = offset.left - scrollLeft + base.options.leftOffset;
+						newLeft = offset.left + base.options.leftOffset;
+			                        if (!base.options.fixScrollLeft) {
+			                            newLeft = newLeft - scrollLeft;
+			                        }
 						base.$originalHeader.css({
 							'position': 'fixed',
 							'margin-top': base.options.marginTop,


### PR DESCRIPTION
Добавил флаг для исправления глюка, когда скроллится див элемент ещё и по горизонтали
```js
    $('table').stickyTableHeaders({
        scrollableArea: $('#blockContent'),
        fixScrollLeft: true
    });
```
И слева был блок fixed. И из-за этого заголовок таблицы гораздо дальше укатывался в лево.