### PR TITLE
Skip some calculations if they are not required

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -145,13 +145,18 @@
 						scrollTop = base.$scrollableArea.scrollTop() + newTopOffset,
 						scrollLeft = base.$scrollableArea.scrollLeft(),
 
-						headerHeight = base.options.cacheHeaderHeight ? base.cachedHeaderHeight : base.$clonedHeader.height(),
+						headerHeight,
 
 						scrolledPastTop = base.isWindowScrolling ?
 								scrollTop > offset.top :
 								newTopOffset > offset.top,
+						notScrolledPastBottom;
+
+					if (scrolledPastTop) {
+						headerHeight = base.options.cacheHeaderHeight ? base.cachedHeaderHeight : base.$clonedHeader.height();
 						notScrolledPastBottom = (base.isWindowScrolling ? scrollTop : 0) <
 							(offset.top + $this.height() - headerHeight - (base.isWindowScrolling ? 0 : newTopOffset));
+					}
 
 					if (scrolledPastTop && notScrolledPastBottom) {
 						newLeft = offset.left - scrollLeft + base.options.leftOffset;


### PR DESCRIPTION
In `toggleHeaders()` several values are always calculated even though they are only used under certain circumstances. In particular, the `base.$clonedHeader.height()` is expensive.

This patch improves scroll performance, in particular when `cacheHeaderHeight` is disabled.
