### PR TITLE
Adding ignoreLeftOffset

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -155,6 +155,9 @@
 
 					if (scrolledPastTop && notScrolledPastBottom) {
 						newLeft = offset.left - scrollLeft + base.options.leftOffset;
+						if( base.options.ignoreLeftOffset === true  ){
+							newLeft = newLeft - offset.left;
+						}
 						base.$originalHeader.css({
 							'position': 'fixed',
 							'margin-top': base.options.marginTop,


### PR DESCRIPTION
If the table is in a bootstrap modal the left offset needs to be ignored and just have a static offset in place, This minor change adds a new option "ignoreLeftOffset" that just subtracts the offset.left from it ( thereby making the offset canceled )