### PR TITLE
INPUT in cloned header (issue #111)

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -70,6 +70,8 @@
 					'</style>');
 				base.$head.append(base.$printStyle);
 			});
+			
+			base.$clonedHeader.find("input, select").attr("disabled", true);
 
 			base.updateWidth();
 			base.toggleHeaders();


### PR DESCRIPTION
To prevent wrong behavior when there are any INPUT elements (eg. checkboxes) in heading cells
ex: on jquery serialize, will populate duplicate input with the same name (one with value, other with empty string)

This fix based on ezoterik solution